### PR TITLE
修正 README.md 中 travis CI 的狀態鏈接 fix #26

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,9 +1,7 @@
+![Build Status](https://travis-ci.org/carbon-bond/carbonbond.svg?branch=master)
+
 # 碳鍵
 提高你的鍵能，把那些笨蛋嘴成渣吧！
-
-## CI
-
-![Build Status](https://travis-ci.org/MROS/carbonbond.svg?branch=master)
 
 ## 建置
 - 設定檔


### PR DESCRIPTION
修正連接，並且把取消掉 "##CI" 這個二階標題。我觀察不少專案都是直接放在 README.md 的最開頭。