### PR TITLE
Hotfix: 修正使用者名稱顯示

### DIFF
--- a/frontend/src/ts/api.ts
+++ b/frontend/src/ts/api.ts
@@ -4,7 +4,7 @@ export type LoginResponse = {
 	login: true
 };
 
-export type Me = { me: { id: string | null } };
+export type Me = { me: { name: string | null } };
 
 function getGraphQLClient(endpoint='/api'): GraphQLClient {
 	return new GraphQLClient(endpoint);
@@ -15,7 +15,7 @@ function me_request(): Promise<Me> {
 	const query = `
 		query {
 			me {
-				id
+				name
 			}
 		}
 	`;

--- a/frontend/src/tsx/global_state.tsx
+++ b/frontend/src/tsx/global_state.tsx
@@ -14,8 +14,8 @@ function useUserState(): { user_state: UserStateType, setLogin: Function, setLog
 
 	async function getLoginState(): Promise<{}> {
 		const data = await api.me_request();
-		if (data.me.id != null) {
-			setUserState({ login: true, user_id: data.me.id });
+		if (data.me.name != null) {
+			setUserState({ login: true, user_id: data.me.name });
 		} else {
 			setUserState({ login: false, fetching: false });
 		}

--- a/src/api.rs
+++ b/src/api.rs
@@ -38,7 +38,7 @@ impl CarbonbondID for ID {
 
 #[derive(juniper::GraphQLObject)]
 struct Me {
-    id: Option<ID>,
+    name: Option<String>,
 }
 
 struct Party {
@@ -296,10 +296,17 @@ struct Query;
 impl Query {
     fn me(ctx: &Ctx) -> Fallible<Me> {
         let me = match ctx.get_id() {
-            None => Me { id: None },
-            Some(id) => Me {
-                id: Some(ID::from_i64(id)),
-            },
+            None => Me { name: None },
+            Some(id) => {
+                use db_schema::users;
+                let user = users::table
+                    .find(id)
+                    .first::<db_models::User>(&ctx.get_pg_conn()?)?;
+
+                Me {
+                    name: Some(user.name),
+                }
+            }
         };
         Ok(me)
     }


### PR DESCRIPTION
修正前次修改資料庫的時候，在前臺漏掉的更改。
未來很多 graphql 還有很多 id 要翻成 name，這個 PR 可大可小，看要不要這次先進再另外開 issue 解決。