### PR TITLE
使文章顯示從新到舊 close #14

### DIFF
--- a/api/api.gql
+++ b/api/api.gql
@@ -69,7 +69,7 @@ type Query {
     article(id: ID!): Article! @juniper(ownership: "owned")
     articleList(
         boardName: String!
-        offset: Int!
+        before: ID          # 若 before 爲空，代表要求最新的
         pageSize: Int!
         showHidden: Boolean
     ): [Article!]! @juniper(ownership: "owned")

--- a/frontend/operation/query.gql
+++ b/frontend/operation/query.gql
@@ -45,11 +45,11 @@ fragment ArticleMeta on Article {
 	board { boardName }
 }
 
-query ArticleList($board_name: String!, $page_size: Int!, $offset: Int!, $show_hidden: Boolean) {
+query ArticleList($board_name: String!, $page_size: Int!, $before: ID, $show_hidden: Boolean) {
 	articleList(
 		boardName: $board_name,
 		pageSize: $page_size,
-		offset: $offset,
+		before: $before,
 		showHidden: $show_hidden
 	) {
 		...ArticleMeta

--- a/frontend/src/tsx/board_switch/board_page.tsx
+++ b/frontend/src/tsx/board_switch/board_page.tsx
@@ -28,6 +28,7 @@ export function BoardPage(props: Props): JSX.Element {
 	let board_name = props.match.params.board_name;
 
 	const [articles, setArticles] = React.useState<ArticleMeta[]>([]);
+	const [is_end, set_is_end] = React.useState<boolean>(false);
 
 	React.useEffect(() => {
 		fetchArticles(board_name, PAGE_SIZE, null).then(more_articles => {
@@ -37,19 +38,21 @@ export function BoardPage(props: Props): JSX.Element {
 	}, [board_name]);
 
 	const scrollHandler = React.useCallback((): void => {
-		// 第一次載入結束前不要動作
-		if (articles.length > 0) {
-			console.log('Touch End');
-			const before = articles.slice(-1)[0].id;
-			fetchArticles(board_name, PAGE_SIZE, before).then(more_articles => {
-				// TODO: 載入到最早的文章就停
-				if (more_articles.length > 0) {
-					console.log(more_articles);
-					setArticles([...articles, ...more_articles]);
-				}
-			});
+		// 第一次載入結束前 or 已經載到最早的文章了，不要動作
+		if (articles.length == 0 || is_end) {
+			return;
 		}
-	}, [articles, board_name]);
+		console.log('Touch End');
+		const before = articles.slice(-1)[0].id;
+		fetchArticles(board_name, PAGE_SIZE, before).then(more_articles => {
+			if (more_articles.length > 0) {
+				console.log(more_articles);
+				setArticles([...articles, ...more_articles]);
+			} else {
+				set_is_end(true);
+			}
+		});
+	}, [articles, board_name, is_end]);
 
 	let { useScrollToBottom } = MainScrollState.useContainer();
 	useScrollToBottom(scrollHandler);

--- a/frontend/src/tsx/board_switch/board_page.tsx
+++ b/frontend/src/tsx/board_switch/board_page.tsx
@@ -18,9 +18,9 @@ type Props = RouteComponentProps<{ board_name: string }>;
 async function fetchArticles(
 	board_name: string,
 	page_size: number,
-	offset: number
+	before: string | null
 ): Promise<ArticleMeta[]> {
-	let res = await ajaxOperation.ArticleList({ board_name, page_size, offset });
+	let res = await ajaxOperation.ArticleList({ board_name, page_size, before, show_hidden: false });
 	return res.articleList;
 }
 
@@ -30,7 +30,7 @@ export function BoardPage(props: Props): JSX.Element {
 	const [articles, setArticles] = React.useState<ArticleMeta[]>([]);
 
 	React.useEffect(() => {
-		fetchArticles(board_name, PAGE_SIZE, 0).then(more_articles => {
+		fetchArticles(board_name, PAGE_SIZE, null).then(more_articles => {
 			console.log(more_articles);
 			setArticles(more_articles);
 		});
@@ -40,8 +40,8 @@ export function BoardPage(props: Props): JSX.Element {
 		// 第一次載入結束前不要動作
 		if (articles.length > 0) {
 			console.log('Touch End');
-			const length = articles.length;
-			fetchArticles(board_name, PAGE_SIZE, length).then(more_articles => {
+			const before = articles.slice(-1)[0].id;
+			fetchArticles(board_name, PAGE_SIZE, before).then(more_articles => {
 				// TODO: 載入到最早的文章就停
 				if (more_articles.length > 0) {
 					console.log(more_articles);

--- a/src/api/query.rs
+++ b/src/api/query.rs
@@ -108,7 +108,7 @@ impl QueryFields for Query {
         ex: &juniper::Executor<'_, Context>,
         _trail: &QueryTrail<'_, Article, juniper_from_schema::Walked>,
         board_name: String,
-        offset: i32,
+        before: Option<ID>,
         page_size: i32,
         show_hidden: Option<bool>,
     ) -> Fallible<Vec<Article>> {
@@ -124,9 +124,12 @@ impl QueryFields for Query {
             query = query.filter(articles::show_in_list.eq(true));
         }
 
+        if let Some(before_id) = before {
+            query = query.filter(articles::id.lt(id_to_i64(&before_id)?));
+        }
+
         let article_vec = query
-            .order(articles::create_time.asc())
-            .offset(offset as i64)
+            .order(articles::create_time.desc())
             .limit(page_size as i64)
             .load::<db_models::Article>(&conn)?;
 


### PR DESCRIPTION
修改原本 offset 的做法（若文章刪除就會漏資料），改爲 cursor-based 的做法。

並且將文章顯示調整爲從新到舊。到最舊的就不再向後端請求

參考 https://ithelp.ithome.com.tw/articles/10207738